### PR TITLE
Update hblink.cfg to use ham-digital DMR ID CSVs

### DIFF
--- a/hblink-SAMPLE.cfg
+++ b/hblink-SAMPLE.cfg
@@ -64,8 +64,8 @@ PATH: ./
 PEER_FILE: peer_ids.csv
 SUBSCRIBER_FILE: subscriber_ids.csv
 TGID_FILE: talkgroup_ids.csv
-PEER_URL: http://dmr-marc.net/static/rptrs.csv
-SUBSCRIBER_URL: http://dmr-marc.net/static/users.csv
+PEER_URL: https://ham-digital.org/status/rptrs.csv
+SUBSCRIBER_URL: https://ham-digital.org/status/users.csv
 STALE_DAYS: 7
 
 # EXPORT AMBE DATA


### PR DESCRIPTION
DMRMarc no longer supply DMR ID CSVs, I've updated to use Ham-Digital instead. Testing and working