### PR TITLE
Update hblink.cfg to use ham-digital DMR ID CSVs

### DIFF
--- a/hblink-SAMPLE.cfg
+++ b/hblink-SAMPLE.cfg
@@ -43,8 +43,8 @@ PATH: ./
 PEER_FILE: peer_ids.csv
 SUBSCRIBER_FILE: subscriber_ids.csv
 TGID_FILE: talkgroup_ids.csv
-PEER_URL: http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=repeaters&format=csv&header=0
-SUBSCRIBER_URL: http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=csv&header=0
+PEER_URL: https://ham-digital.org/status/rptrs.csv
+SUBSCRIBER_URL: https://ham-digital.org/status/users.csv
 STALE_DAYS: 7
 
 # EXPORT AMBE DATA


### PR DESCRIPTION
Update hblink.cfg to use ham-digital DMR ID CSVs